### PR TITLE
Remove event listeners on critical error

### DIFF
--- a/lib/square.js
+++ b/lib/square.js
@@ -914,8 +914,8 @@ Square.prototype.merge = function merge (extension, groupsout) {
       );
     }, function done (err) {
       if (err) {
-        // Remove merge listener on critical errors otherwise
-        // while watching we will get mulitple merges.
+        // Remove merge listener, otherwise while 
+        // watching we will get mulitple builds.
         self.removeAllListeners('merge');
 
         return this.logger.critical(


### PR DESCRIPTION
Critical errors while watching, specifically external files like stylus, will result in double builds after the error is fixed in the dependency
